### PR TITLE
Replace deprecated apis from scipy.misc with their official substitutions; Add align_corners=False to get rid of a warning.

### DIFF
--- a/lib/models/hrnet.py
+++ b/lib/models/hrnet.py
@@ -238,7 +238,8 @@ class HighResolutionModule(nn.Module):
                     y = y + F.interpolate(
                         self.fuse_layers[i][j](x[j]),
                         size=[x[i].shape[2], x[i].shape[3]],
-                        mode='bilinear')
+                        mode='bilinear',
+                        align_corners=False)
                 else:
                     y = y + self.fuse_layers[i][j](x[j])
             x_fuse.append(self.relu(y))

--- a/lib/utils/transforms.py
+++ b/lib/utils/transforms.py
@@ -7,8 +7,9 @@
 import cv2
 import torch
 import scipy
-import scipy.misc
+import skimage
 import numpy as np
+from PIL import Image
 
 
 MATCHED_PARTS = {
@@ -175,7 +176,7 @@ def crop(img, center, scale, output_size, rot=0):
             return torch.zeros(output_size[0], output_size[1], img.shape[2]) \
                         if len(img.shape) > 2 else torch.zeros(output_size[0], output_size[1])
         else:
-            img = scipy.misc.imresize(img, [new_ht, new_wd])  # (0-1)-->(0-255)
+            img = np.array(Image.fromarray(img.astype(np.uint8)).resize([new_wd, new_ht]))  # (0-1)-->(0-255)
             center_new[0] = center_new[0] * 1.0 / sf
             center_new[1] = center_new[1] * 1.0 / sf
             scale = scale / sf
@@ -207,9 +208,9 @@ def crop(img, center, scale, output_size, rot=0):
 
     if not rot == 0:
         # Remove padding
-        new_img = scipy.misc.imrotate(new_img, rot)
+        new_img = skimage.transform.rotate(new_img, rot)
         new_img = new_img[pad:-pad, pad:-pad]
-    new_img = scipy.misc.imresize(new_img, output_size)
+    new_img = np.array(Image.fromarray(new_img.astype(np.uint8)).resize(output_size))
     return new_img
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 hdf5storage
 yacs
+scikit-image
+pillow


### PR DESCRIPTION
- Every use of `scipy.misc.imresize` and `scipy.misc.imrotate` from `lib/utils/transform.py` is replaced by their official recommended substitutions:
  - https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imresize.html:
    > imresize is deprecated! imresize is deprecated in SciPy 1.0.0, and will be removed in 1.3.0. Use Pillow instead: numpy.array(Image.fromarray(arr).resize()).
  - https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.misc.imrotate.html:
    > imrotate is deprecated! imrotate is deprecated in SciPy 1.0.0, and will be removed in 1.2.0. Use skimage.transform.rotate instead.
  - Therefore, add `scikit-image` and `pillow` to `requirements.txt` to use the new apis.
- Add `align_corners=False` to get rid of the warning from `torch.nn.functional.interpolate` since `torch>=0.4.0`.